### PR TITLE
always link libm to libast.so and libast_pal.so

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ conda search starlink-ast --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,10 @@ source:
   patches:
     - patches/osx-11-configure.patch
     - patches/cross-compile-makefile.patch
+    - patches/link-libm.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 

--- a/recipe/patches/link-libm.patch
+++ b/recipe/patches/link-libm.patch
@@ -1,0 +1,20 @@
+--- Makefile.in.orig	2021-11-08 20:11:53.098084535 -0800
++++ Makefile.in	2021-11-08 20:20:48.559434015 -0800
+@@ -1572,7 +1572,7 @@
+     $(WCSLIB_FILES) \
+     ast_err.h
+ 
+-libast_la_LDFLAGS = -version-info @version_info@
++libast_la_LDFLAGS = -version-info @version_info@ -lm
+ @EXTERNAL_CMINPACK_FALSE@@EXTERNAL_PAL_FALSE@libast_la_LIBADD = libast_pal.la libast_cminpack.la
+ @EXTERNAL_CMINPACK_FALSE@@EXTERNAL_PAL_TRUE@libast_la_LIBADD = $(libdir)/libpal.la libast_cminpack.la
+ @EXTERNAL_CMINPACK_TRUE@@EXTERNAL_PAL_FALSE@libast_la_LIBADD = libast_pal.la -lcminpack
+@@ -1633,7 +1633,7 @@
+ 
+ #  Positional astronomy libraries.
+ libast_pal_la_SOURCES = $(PAL_FILES)
+-libast_pal_la_LDFLAGS = -version-info @version_info@
++libast_pal_la_LDFLAGS = -version-info @version_info@ -lm
+ 
+ #  Cminpack
+ libast_cminpack_la_SOURCES = $(CMINPACK_FILES)


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
libast_pal.so and libast.so have undefined references to libm.so. Depending on the linker (version) used 
this can lead to a crash of executables linked against these library at startup (shlib resolution/loading). 
This fix add -lm to the above libraries to fix this problem.
-->
